### PR TITLE
Upgrades Zeitwerk dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     h3 (3.7.2)
       ffi (~> 1.9)
       rgeo-geojson (~> 2.1)
-      zeitwerk (~> 2.1)
+      zeitwerk (~> 2.5)
 
 GEM
   remote: https://rubygems.org/
@@ -41,4 +41,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.1.4
+   2.2.22

--- a/h3.gemspec
+++ b/h3.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "ffi", "~> 1.9"
   spec.add_runtime_dependency "rgeo-geojson", "~> 2.1"
-  spec.add_runtime_dependency "zeitwerk", "~> 2.1"
+  spec.add_runtime_dependency "zeitwerk", "~> 2.5"
 
   # spec.add_development_dependency "coveralls", "~> 0.8"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
The dependency on Zeitwerk was bumped in the automatic PR #77. Here we sync the gemspec.