### PR TITLE
Fix segfault when from_string is passed nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 We track the MAJOR and MINOR version levels of Uber's H3 project (https://github.com/uber/h3) but maintain independent patch levels so we can make small fixes and non breaking changes.
 
+## [3.7.3] - Unreleased
+### Fixed
+- `H3.from_string(nil)` should not crash
+
 ## [3.7.2] - 2020-07-17
 ### Fixed
 - kRing of invalid indexes should not crash.

--- a/lib/h3/bindings/private.rb
+++ b/lib/h3/bindings/private.rb
@@ -57,6 +57,7 @@ module H3
       attach_function :point_distance_m, :pointDistM, [GeoCoord, GeoCoord], :double
       attach_function :polyfill, [GeoPolygon, Resolution, H3IndexesOut], :void
       attach_function :res_0_indexes, :getRes0Indexes, [H3IndexesOut], :void
+      attach_function :string_to_h3, :stringToH3, %i[string], :h3_index
       attach_function :uncompact, [H3IndexesIn, :size_t, H3IndexesOut, :size_t, Resolution], :bool
     end
   end

--- a/lib/h3/inspection.rb
+++ b/lib/h3/inspection.rb
@@ -44,8 +44,13 @@ module H3
     #   H3.from_string("8928308280fffff")
     #   617700169958293503
     #
+    # @raise [ArgumentError] If h3_string is nil
+    #
     # @return [Integer] H3 index
-    attach_function :from_string, :stringToH3, %i[string], :h3_index
+    def from_string(h3_string)
+      raise ArgumentError if h3_string.nil?
+      Bindings::Private.string_to_h3(h3_string)
+    end
 
     # @!method pentagon?(h3_index)
     #

--- a/spec/inspection_spec.rb
+++ b/spec/inspection_spec.rb
@@ -20,12 +20,21 @@ RSpec.describe H3 do
   end
 
   describe ".from_string" do
-    let(:h3_index) { "8928308280fffff"}
-    let(:result) { h3_index.to_i(16) }
-
     subject(:from_string) { H3.from_string(h3_index) }
+    context "- valid" do
+      let(:h3_index) { "8928308280fffff"}
+      let(:result) { h3_index.to_i(16) }
 
-    it { is_expected.to eq(result) }
+      it { is_expected.to eq(result) }
+    end
+
+    context "- nil" do
+      let(:h3_index) { nil }
+
+      it "raises an error" do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
   end
 
   describe ".to_string" do


### PR DESCRIPTION
Hi @seanhandley,

This PR fixes an error when `H3.from_string` is passed a `nil` from ruby.

Hope it meets your expectations for a simple contribution.

By the way, are you looking for any help with the 4.x upgrade? I might be able to find some time in the new year.