### PR TITLE
Fix building on Nix

### DIFF
--- a/ext/h3/Makefile
+++ b/ext/h3/Makefile
@@ -1,5 +1,5 @@
 make:
-	cd src; cmake . -DBUILD_SHARED_LIBS=true -DBUILD_FILTERS=OFF -DBUILD_BENCHMARKS=OFF; make
+	cd src; cmake . -DBUILD_SHARED_LIBS=true -DBUILD_FILTERS=OFF -DBUILD_BENCHMARKS=OFF -DENABLE_LINTING=OFF; make
 install:
 	: # do nothing, we'll load the lib directly
 clean:


### PR DESCRIPTION
Adds cmake option to disable linting, which fails the build on Nix environment. It seems that `h3` packages also passess the same [flag](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/misc/h3/default.nix#L32).

Error log:
```
Resolving dependencies...
Installing h3 3.7.2 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
    current directory: /redacted/.dev/gem/gems/h3-3.7.2/ext/h3
/nix/store/ngba37jnamnq45fhh1qldz8vbdj9kgb6-ruby-3.3.4/bin/ruby extconf.rb
current directory: /redacted/.dev/gem/gems/h3-3.7.2/ext/h3
make DESTDIR\= sitearchdir\=./.gem.20240924-37029-xwfaix sitelibdir\=./.gem.20240924-37029-xwfaix clean
: # do nothing, cleanup happens when gem uninstalled
current directory: /redacted/.dev/gem/gems/h3-3.7.2/ext/h3
make DESTDIR\= sitearchdir\=./.gem.20240924-37029-xwfaix sitelibdir\=./.gem.20240924-37029-xwfaix
cd src; cmake . -DBUILD_SHARED_LIBS=true -DBUILD_FILTERS=OFF -DBUILD_BENCHMARKS=OFF; make
CMake Deprecation Warning at CMakeLists.txt:15 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.
  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
-- The C compiler identification is Clang 16.0.6
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /nix/store/8c3v3rdzvi5364x9m959ijyy6iamqf5f-clang-wrapper-16.0.6/bin/clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE) 
-- Configuring done (1.0s)
-- Generating done (0.3s)
-- Build files have been written to: /redacted/.dev/gem/gems/h3-3.7.2/ext/h3/src
make[1]: Entering directory '/redacted/.dev/gem/gems/h3-3.7.2/ext/h3/src'
[  0%] Formatting sources
[  0%] Built target format
[  1%] Building C object CMakeFiles/h3.dir/src/h3lib/lib/algos.c.o
/redacted/.dev/gem/gems/h3-3.7.2/ext/h3/src/src/h3lib/include/bbox.h:23:10: error: 'stdbool.h' file not found [clang-diagnostic-error]
#include <stdbool.h>
         ^~~~~~~~~~~
1 error generated.
Error while processing /redacted/.dev/gem/gems/h3-3.7.2/ext/h3/src/src/h3lib/lib/algos.c.
Found compiler error(s).
make[3]: *** [CMakeFiles/h3.dir/build.make:76: CMakeFiles/h3.dir/src/h3lib/lib/algos.c.o] Error 1
make[2]: *** [CMakeFiles/Makefile2:1065: CMakeFiles/h3.dir/all] Error 2
make[1]: *** [Makefile:166: all] Error 2
```