### PR TITLE
Fix builds with CMake 4

### DIFF
--- a/ext/h3/Makefile
+++ b/ext/h3/Makefile
@@ -1,5 +1,5 @@
 make:
-	cd src; cmake . -DBUILD_SHARED_LIBS=true -DBUILD_FILTERS=OFF -DBUILD_BENCHMARKS=OFF -DENABLE_LINTING=OFF; make
+	cd src; cmake . -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DBUILD_SHARED_LIBS=true -DBUILD_FILTERS=OFF -DBUILD_BENCHMARKS=OFF -DENABLE_LINTING=OFF; make
 install:
 	: # do nothing, we'll load the lib directly
 clean:


### PR DESCRIPTION
Fixes building with CMake 4
```
┃┃ Resolving dependencies...
┃┃ Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
┃┃     current directory: /Users/vaidas/.gem/ruby/3.4.2/bundler/gems/h3_ruby-5d0f52d14ca7/ext/h3
┃┃ /opt/rubies/3.4.2/bin/ruby extconf.rb
┃┃ current directory: /Users/vaidas/.gem/ruby/3.4.2/bundler/gems/h3_ruby-5d0f52d14ca7/ext/h3
┃┃ make DESTDIR\= sitearchdir\=./.gem.20250403-97544-9yeney sitelibdir\=./.gem.20250403-97544-9yeney clean
┃┃ : # do nothing, cleanup happens when gem uninstalled
┃┃ current directory: /Users/vaidas/.gem/ruby/3.4.2/bundler/gems/h3_ruby-5d0f52d14ca7/ext/h3
┃┃ make DESTDIR\= sitearchdir\=./.gem.20250403-97544-9yeney sitelibdir\=./.gem.20250403-97544-9yeney
┃┃ cd src; cmake . -DBUILD_SHARED_LIBS=true -DBUILD_FILTERS=OFF -DBUILD_BENCHMARKS=OFF -DENABLE_LINTING=OFF; make
┃┃ CMake Error at CMakeLists.txt:15 (cmake_minimum_required):
┃┃   Compatibility with CMake < 3.5 has been removed from CMake.
┃┃   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
┃┃   to tell CMake that the project requires at least <min> but has been updated
┃┃   to work with policies introduced by <max> or earlier.
┃┃   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
┃┃ -- Configuring incomplete, errors occurred!
┃┃ make[1]: *** No targets specified and no makefile found.  Stop.
┃┃ make: *** [make] Error 2
┃┃ make failed, exit code 2
```